### PR TITLE
(tweak) Removing a hardcoded slack channel name

### DIFF
--- a/cinq_auditor_ebs/__init__.py
+++ b/cinq_auditor_ebs/__init__.py
@@ -48,8 +48,6 @@ class EBSAuditor(BaseAuditor):
 
         notices = {}
         for account, issues in data.items():
-            account.contacts.append('#akjaer-slack-test')
-
             for issue in issues['issues']:
                 for recipient in account.contacts:
                     notices.setdefault(recipient, {'issues': [], 'fixed': []})['issues'].append(issue)


### PR DESCRIPTION
Some debugging code was left behind to log to a hard-coded slack channel